### PR TITLE
User login, logout and signup

### DIFF
--- a/hlpoc/forms.py
+++ b/hlpoc/forms.py
@@ -1,0 +1,19 @@
+from django import forms
+from django.contrib.auth.forms import UserCreationForm
+from django.contrib.auth.models import User
+
+
+class SignUpForm(UserCreationForm):
+    first_name = forms.CharField(max_length=30,
+                                 required=False,
+                                 help_text='Optional')
+    last_name = forms.CharField(max_length=30,
+                                required=False,
+                                help_text='Optional.')
+    email = forms.EmailField(max_length=254,
+                             help_text='Required. Should be a valid email.')
+
+    class Meta:
+        model = User
+        fields = ('username', 'first_name', 'last_name',
+                  'email', 'password1', 'password2', )

--- a/hlpoc/templates/layouts/header.html
+++ b/hlpoc/templates/layouts/header.html
@@ -22,7 +22,7 @@
     <header>
       <!-- Fixed navbar -->
       <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-dark">
-        <a class="navbar-brand" href="#">
+        <a class="navbar-brand" href="{% url 'index' %}">
           <img src="{% static 'images/woodchuck_inv_50.jpg' %}" />
           AKASQ
         </a>
@@ -31,6 +31,7 @@
         </button>
         <div class="collapse navbar-collapse" id="navbarCollapse">
           <ul class="navbar-nav mr-auto">
+            {% if user.is_authenticated %}
             <li class="nav-item active">
               <a class="nav-link" href="#">Home <span class="sr-only">(current)</span></a>
             </li>
@@ -40,11 +41,23 @@
             <li class="nav-item">
               <a class="nav-link disabled" href="#">Disabled</a>
             </li>
+            {% endif %}
           </ul>
-          <form class="form-inline mt-2 mt-md-0">
-            <input class="form-control mr-sm-2" type="text" placeholder="Search" aria-label="Search">
-            <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Search</button>
-          </form>
+          <ul class="navbar-nav ml-auto">
+            {% if user.is_authenticated %}
+            <li class="nav-item">
+              <a class="nav-link text-white" href="#">{{request.user.username}}</a>
+            </li>
+            <li class="nav-item">
+              <a class="btn btn-secondary" href="{% url 'logout' %}" role="button">Log Out</a>
+            </li>
+            {% else %}
+            <li class="nav-item">
+              <a class="btn btn-secondary" href="{% url 'signup' %}" role="button">Sign Up</a>
+              <a class="btn btn-secondary" href="{% url 'login' %}" role="button">Log In</a>
+            </li>
+            {% endif %}
+          </ul>
         </div>
       </nav>
     </header>

--- a/hlpoc/templates/users/login.html
+++ b/hlpoc/templates/users/login.html
@@ -1,0 +1,10 @@
+{% extends 'layouts/base.html' %}
+
+{% block content %}
+  <h2>Login</h2>
+  <form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button class="btn btn-secondary" type="submit">Login</button>
+  </form>
+{% endblock %}

--- a/hlpoc/templates/users/signup.html
+++ b/hlpoc/templates/users/signup.html
@@ -1,0 +1,23 @@
+{% extends 'layouts/base.html' %}
+
+{% block content %}
+  <h2>Sign up</h2>
+  <form method="post">
+    {% csrf_token %}
+    {% for field in form %}
+      <p>
+        {{ field.label_tag }}<br>
+        {{ field }}
+        {% if field.help_text %}
+          <small style="color: grey">{{ field.help_text }}</small>
+        {% endif %}
+        {% for error in field.errors %}
+          <p style="color: red">{{ error }}</p>
+        {% endfor %}
+      </p>
+    {% endfor %}
+    <button class="btn btn-secondary" type="submit">Sign up</button>
+  </form>
+
+  If you already have an account - <a href="{% url 'login' %}" target="blank"><strong>login</strong></a>
+{% endblock %}

--- a/hlpoc/urls.py
+++ b/hlpoc/urls.py
@@ -1,7 +1,12 @@
 from django.urls import path
-
+from django.contrib.auth import views as auth_views
 from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
+    path('signup/', views.signup, name='signup'),
+    path('login/',
+         auth_views.LoginView.as_view(template_name='users/login.html'),
+         name='login'),
+    path('logout/', auth_views.LogoutView.as_view(), name='logout'),
 ]

--- a/hlpoc/views.py
+++ b/hlpoc/views.py
@@ -1,7 +1,27 @@
 from django.template import loader
 from django.http import HttpResponse
+from django.shortcuts import render, redirect
+from hlpoc.forms import SignUpForm
+from django.contrib.auth import login as auth_login, authenticate
 
 
 def index(request):
     template = loader.get_template('index.html')
     return HttpResponse(template.render({}, request))
+
+
+def signup(request):
+    if request.method == 'POST':
+        form = SignUpForm(request.POST)
+        if form.is_valid():
+            form.save()
+            username = form.cleaned_data.get('username')
+            raw_password = form.cleaned_data.get('password1')
+            user = authenticate(username=username, password=raw_password)
+            auth_login(request, user)
+            return redirect('index')
+    else:
+        form = SignUpForm()
+    return render(request=request,
+                  template_name='users/signup.html',
+                  context={'form': form})

--- a/portal/settings.py
+++ b/portal/settings.py
@@ -149,3 +149,6 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, "static"),
 )
+
+LOGIN_REDIRECT_URL = 'index'
+LOGOUT_REDIRECT_URL = 'index'

--- a/portal/settings.py
+++ b/portal/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = os.getenv('SECRET_KEY', 'nososecret')
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = os.getenv('DJANGO_DEBUG', 'True') == 'True'
 
-ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS', '').split(',')
+ALLOWED_HOSTS = [x for x in os.getenv('ALLOWED_HOSTS', '').split(',') if x]
 
 if os.getenv('SSL_REDIRECT', 'False') == 'True':
   SECURE_SSL_REDIRECT = True


### PR DESCRIPTION
I have made the whole thing as simple as possible except that I have partially redefined built-in Django authentication system parts: it has out-of-the-box authentication mechanism including user login/logout forms, user signup form, default path where it expects to see templates, etc. It even encourages you to move whole user-related auth stuff into a separate app, like `accounts`, along with your primary app (`hlpoc` in our case). I have read here and there and now decided to keep everything the way I did: it has some samples how to create a custom form (`SignUpForm`), it has some samples of how to redefine a template for any of existing auth forms (`login` and `logout`). And it simply works. If we, at some point, will need to refactor the thing (and ofc we will if PoC goes somewhere beyond PoC area) - it is not that hard to restructure that.